### PR TITLE
.tsx is file type TypeScript

### DIFF
--- a/src/exportProject.ts
+++ b/src/exportProject.ts
@@ -157,6 +157,8 @@ function getProjectFileType(name: string): ProjectFileType {
 	switch (ext) {
 	case '.ts':
 		return /\.d\.ts$/.test(name) ? ProjectFileType.Definition : ProjectFileType.TypeScript;
+	case '.tsx':
+		return ProjectFileType.TypeScript;
 	case '.html':
 		return ProjectFileType.HTML;
 	case '.css':
@@ -250,7 +252,7 @@ async function addDependencies(project: ProjectJson) {
  * @param project The reference to the project bundle
  * @param includeExtensions A comma deliminated string of extensions to be included in the project files
  */
-async function addProjectFiles(project: ProjectJson, includeExtensions: string = 'ts,html,css,json,xml,md') {
+async function addProjectFiles(project: ProjectJson, includeExtensions: string = 'ts,tsx,html,css,json,xml,md') {
 	if (project.tsconfig.include) {
 		const globs = await Promise.all(
 			project.tsconfig.include

--- a/tests/unit/exportProject.ts
+++ b/tests/unit/exportProject.ts
@@ -127,7 +127,7 @@ registerSuite({
 			'node_modules/baz/package.json': JSON.stringify({ })
 		};
 		globMap = {
-			'src/**/*.{ts,html,css,json,xml,md}': [ './src/index.html' ]
+			'src/**/*.{ts,tsx,html,css,json,xml,md}': [ './src/index.html' ]
 		};
 		resolveMap = {};
 	},
@@ -264,7 +264,7 @@ registerSuite({
 	},
 
 	async 'adds project files based on tsconfig.json'() {
-		globMap['src/**/*.{ts,html,css,json,xml,md}'] = [
+		globMap['src/**/*.{ts,tsx,html,css,json,xml,md}'] = [
 			'src/index.ts',
 			'./src/index.html',
 			'src/core.css',
@@ -272,11 +272,12 @@ registerSuite({
 			'src/config/build.xml',
 			'src/README.md',
 			'src/interfaces.d.ts',
-			'src/text.txt'
+			'src/text.txt',
+			'src/widgets/Foo.tsx'
 		];
 		readFileMap['tsconfig.json'] = JSON.stringify({
 			compilerOptions: { },
-			include: [ 'src/**/*.ts' ]
+			include: [ 'src/**/*.ts', 'src/**/*.tsx' ]
 		});
 		await exportProject(exportArgs);
 		assert.strictEqual(consoleLogStub.callCount, 2, 'should have only logged twice to console');
@@ -291,13 +292,14 @@ registerSuite({
 				{ name: 'src/config/build.xml', text: '', type: ProjectFileType.XML },
 				{ name: 'src/README.md', text: '', type: ProjectFileType.Markdown },
 				{ name: 'src/interfaces.d.ts', text: '', type: ProjectFileType.Definition },
-				{ name: 'src/text.txt', text: '', type: ProjectFileType.PlainText }
+				{ name: 'src/text.txt', text: '', type: ProjectFileType.PlainText },
+				{ name: 'src/widgets/Foo.tsx', text: '', type: ProjectFileType.TypeScript }
 			],
 			index: './src/index.html',
 			package: { name: 'test-package' },
 			tsconfig: {
 				compilerOptions: {},
-				include: [ 'src/**/*.ts' ]
+				include: [ 'src/**/*.ts', 'src/**/*.tsx' ]
 			}
 		}, 'should have written expected contents');
 	},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR adds support for exporting of `.tsx` files from a project.

Resolves #3
