### PR TITLE
Update to TypeScript 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@dojo/cli": "beta1",
-    "@dojo/loader": "beta1",
+    "@dojo/cli": "next",
+    "@dojo/loader": "next",
     "@types/chalk": "^0.4.31",
     "@types/glob": "^5.0.30",
     "@types/grunt": "^0.4.21",
@@ -36,7 +36,7 @@
     "mockery": "^1.7.0",
     "monaco-editor": "^0.8.3",
     "sinon": "^1.17.5",
-    "typescript": "~2.2.2",
+    "typescript": "~2.4.1",
     "yargs": "^5.0.0"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,12 @@
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
-		"noImplicitAny": true,
-		"noImplicitThis": true,
-		"strictNullChecks": true,
+		"moduleResolution": "node",
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es6",
-		"moduleResolution": "node",
+		"strict": true,
+		"target": "es2016",
 		"types": [ "intern", "monaco-editor" ]
 	},
 	"include": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR updates to TypeScript 2.4, migrates to the `strict` and `es2016` compiler options.

Refs: dojo/meta#189
