### PR TITLE
Migrate to @dojo/interfaces/cli and @types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@dojo/cli": "next",
+    "@dojo/interfaces": "next",
     "@dojo/loader": "next",
     "@types/chalk": "^0.4.31",
     "@types/glob": "^5.0.30",
@@ -29,6 +29,7 @@
     "@types/mockery": "^1.4.29",
     "@types/node": "^6.0.0",
     "@types/sinon": "^1.16.35",
+    "@types/yargs": "^8.0.2",
     "glob": "^7.1.1",
     "grunt": "~1.0.1",
     "grunt-dojo2": "beta1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,9 @@
-import { Command, Helper, OptionsHelper } from '@dojo/cli/interfaces';
-import { Argv } from 'yargs';
+import { Command, Helper, OptionsHelper } from '@dojo/interfaces/cli';
 import { join } from 'path';
 import exportProject from './exportProject';
 const pkgDir = require('pkg-dir');
 
-export interface ExportArgs extends Argv {
+export interface ExportArgs {
 	content: string | undefined;
 	out: string;
 	index: string | undefined;
@@ -25,7 +24,7 @@ function buildNpmDependencies(): { [ pkg: string ]: string } {
 	}
 }
 
-const command: Command = {
+const command: Command<ExportArgs> = {
 	description: 'Emit a JSON file that describes the project.',
 
 	register(options: OptionsHelper) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
 		"types": [ "intern", "monaco-editor" ]
 	},
 	"include": [
-		"./typings/index.d.ts",
 		"./src/**/*.ts",
 		"./tests/**/*.ts"
 	]

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-	"name": "dojo-cli-test-intern",
-	"dependencies": {
-		"yargs": "registry:npm/yargs#5.0.0+20160907000723"
-	}
-}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Migrate to use `@dojo/interfaces/cli` and `@types` for other typings.

Refs: https://github.com/dojo/cli/issues/119