### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -41,8 +41,17 @@ There are several options that can be passed on the command line:
 
 ## How do I contribute?
 
-We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,12 @@
       "dev": true
     },
     "@dojo/interfaces": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
-      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -39,7 +39,7 @@
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/digdug": {
@@ -50,11 +50,11 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/leadfoot": {
@@ -65,17 +65,17 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
-      "version": "6.25.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
       "dev": true
     },
     "@types/benchmark": {
@@ -91,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/chalk": {
@@ -112,13 +112,19 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -128,17 +134,17 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.0",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.57",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
+      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/fs-extra": {
@@ -147,17 +153,18 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "6.0.95"
       }
     },
     "@types/grunt": {
@@ -166,7 +173,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/handlebars": {
@@ -200,14 +207,22 @@
       "dev": true
     },
     "@types/istanbul-lib-instrument": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-      "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
+      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.2",
+        "@types/babel-types": "7.0.0",
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-lib-report": {
@@ -220,13 +235,21 @@
       }
     },
     "@types/istanbul-lib-source-maps": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-      "integrity": "sha512-GxjyOSIZC/HETEo61MOjM72qdZH0F9UwfuXCKhmgqhVC7PSjE61BU2I/2eZwQ43+kSdkxKvnOBqqNZi1HHHNEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+      "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-reports": {
@@ -246,9 +269,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -270,9 +293,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
       "dev": true
     },
     "@types/mockery": {
@@ -282,9 +305,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.92",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+      "version": "6.0.95",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.95.tgz",
+      "integrity": "sha512-d1Twx1NM49dQ7jbNZfaHTQWuYL9cFVrGxYpbc3BvMf4626lOJOZnp2aJQNB9vP/WX3UOe1TrTUMABrGRu6FZhg==",
       "dev": true
     },
     "@types/platform": {
@@ -299,7 +322,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/serve-static": {
@@ -308,7 +331,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.0",
         "@types/mime": "2.0.0"
       }
     },
@@ -324,7 +347,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/sinon": {
@@ -351,13 +374,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.95"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "abbrev": {
@@ -437,6 +460,21 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -446,6 +484,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
     },
     "any-promise": {
       "version": "1.3.0",
@@ -462,6 +512,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -595,7 +651,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000784",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -659,14 +715,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -945,8 +1001,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
-        "electron-to-chromium": "1.3.28"
+        "caniuse-db": "1.0.30000784",
+        "electron-to-chromium": "1.3.30"
       }
     },
     "buffer": {
@@ -1009,15 +1065,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000784",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000784",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000784.tgz",
+      "integrity": "sha1-G+lQEtlInHcZB0+BruV9vf/mNhs=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1101,6 +1157,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1115,6 +1177,53 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1214,6 +1323,12 @@
       "requires": {
         "color-name": "1.1.3"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
@@ -1351,6 +1466,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1586,6 +1740,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1689,6 +1849,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1842,10 +2008,25 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
+    "electron-releases": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
+      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
+      "dev": true
+    },
     "electron-to-chromium": {
-      "version": "1.3.28",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+      "version": "1.3.30",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
+      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
+      "dev": true,
+      "requires": {
+        "electron-releases": "2.1.0"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emojis-list": {
@@ -1920,6 +2101,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -1968,6 +2159,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2078,14 +2275,21 @@
       }
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2115,6 +2319,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2185,6 +2399,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2353,6 +2573,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -2647,7 +2873,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.3",
+        "intern": "4.1.4",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -2666,11 +2892,40 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
         }
       }
     },
@@ -2797,9 +3052,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -2822,7 +3077,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3038,6 +3293,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3110,30 +3390,30 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
+      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
       "dev": true,
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
         "@types/http-errors": "1.5.34",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/istanbul-lib-hook": "1.0.0",
-        "@types/istanbul-lib-instrument": "1.7.0",
+        "@types/istanbul-lib-instrument": "1.7.1",
         "@types/istanbul-lib-report": "1.1.0",
-        "@types/istanbul-lib-source-maps": "1.2.0",
+        "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3163,7 +3443,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -3358,6 +3638,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3443,6 +3738,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3470,10 +3774,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -3727,6 +4043,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -3857,6 +4234,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3876,11 +4259,247 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4072,6 +4691,62 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
     "lolex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -4143,9 +4818,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
       "dev": true
     },
     "make-error-cause": {
@@ -4154,7 +4829,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "1.3.0"
+        "make-error": "1.3.2"
       }
     },
     "map-obj": {
@@ -4164,9 +4839,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -4408,6 +5083,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4415,6 +5099,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4492,6 +5195,12 @@
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -4530,6 +5239,18 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "os-homedir": {
@@ -4623,6 +5344,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -5268,7 +5995,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14",
+        "postcss": "6.0.15",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -5290,6 +6017,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5299,14 +6037,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5316,9 +6054,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5467,7 +6205,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5488,6 +6226,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5497,14 +6246,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5514,9 +6263,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5531,7 +6280,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5552,6 +6301,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5561,14 +6321,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5578,9 +6338,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5595,7 +6355,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5616,6 +6376,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5625,14 +6396,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5642,9 +6413,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5659,7 +6430,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5680,6 +6451,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5689,14 +6471,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5706,9 +6488,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5931,6 +6713,39 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -6231,9 +7046,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -6374,6 +7189,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6398,6 +7219,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -6435,6 +7266,23 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -6632,6 +7480,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6705,6 +7559,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -6718,6 +7578,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6770,6 +7639,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6856,6 +7736,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tape": {
       "version": "2.3.0",
@@ -7117,15 +8003,15 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7134,9 +8020,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7144,7 +8031,26 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -8367,7 +9273,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -8375,7 +9281,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "url": "https://github.com/dojo/cli-export-project.git"
   },
   "scripts": {
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "devDependencies": {
@@ -33,19 +35,23 @@
     "grunt": "~1.0.1",
     "grunt-contrib-clean": ">=1.0.0",
     "grunt-contrib-copy": ">=1.0.0",
+    "grunt-dojo2": "latest",
     "grunt-postcss": "^0.8.0",
     "grunt-text-replace": ">=0.4.0",
     "grunt-ts": ">=5.0.0",
-    "grunt-tslint": "^4.0.1",
+    "grunt-tslint": "5.0.1",
     "grunt-typings": "^0.1.5",
-    "grunt-dojo2": "latest",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "mockery": "^1.7.0",
     "monaco-editor": "^0.8.3",
+    "prettier": "1.9.2",
     "remap-istanbul": ">=0.6.3",
     "sinon": "^1.17.5",
     "tslib": "~1.8.0",
-    "tslint": "^4.5.1",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1",
     "yargs": "^5.0.0"
   },
@@ -54,5 +60,19 @@
     "glob": "^7.1.1",
     "pkg-dir": "^1.0.0",
     "resolve-cwd": "^1.0.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/src/exportProject.ts
+++ b/src/exportProject.ts
@@ -18,7 +18,7 @@ const DOJO_EXCLUDE = /@dojo\/loader\/interfaces\.d\.ts$/;
 
 export let requireResolve = resolveCwd;
 
-export type StringMap = { [ pkg: string ]: string; };
+export type StringMap = { [pkg: string]: string };
 
 /**
  * Helper function to create a new project file entry
@@ -26,7 +26,11 @@ export type StringMap = { [ pkg: string ]: string; };
  * @param text The text of the file
  * @param type The file type
  */
-function createProjectFile(name: string, text: string, type: ProjectFileType = ProjectFileType.Definition): ProjectFile {
+function createProjectFile(
+	name: string,
+	text: string,
+	type: ProjectFileType = ProjectFileType.Definition
+): ProjectFile {
 	return { name, text, type };
 }
 
@@ -107,8 +111,8 @@ async function createProject() {
 		tsconfig: {}
 	};
 
-	if (!(await exists('package.json') && await exists('tsconfig.json'))) {
-		throw new Error(`Path "${ cwd() }" does not contain a "tsconfig.json" and "package.json".`);
+	if (!((await exists('package.json')) && (await exists('tsconfig.json')))) {
+		throw new Error(`Path "${cwd()}" does not contain a "tsconfig.json" and "package.json".`);
 	}
 
 	verbose(indent(), bold.blue('reading'), ' "package.json"');
@@ -130,17 +134,16 @@ async function createProject() {
  */
 async function addLibFiles(project: ProjectJson) {
 	if (project.tsconfig.compilerOptions && project.tsconfig.compilerOptions.lib) {
-		const tasks = project.tsconfig.compilerOptions.lib
-			.map(async (lib) => {
-				const filename = `lib.${ lib }.d.ts`;
-				const projectDescriptor = createProjectFile(
-					filename,
-					await getFile(join('node_modules', 'typescript', 'lib', filename)),
-					ProjectFileType.Lib
-				);
-				project.environmentFiles.push(projectDescriptor);
-				verbose(indent(), bold.blue('adding'), ` lib "${ lib }"`);
-			});
+		const tasks = project.tsconfig.compilerOptions.lib.map(async (lib) => {
+			const filename = `lib.${lib}.d.ts`;
+			const projectDescriptor = createProjectFile(
+				filename,
+				await getFile(join('node_modules', 'typescript', 'lib', filename)),
+				ProjectFileType.Lib
+			);
+			project.environmentFiles.push(projectDescriptor);
+			verbose(indent(), bold.blue('adding'), ` lib "${lib}"`);
+		});
 
 		return Promise.all(tasks);
 	}
@@ -155,22 +158,22 @@ function getProjectFileType(name: string): ProjectFileType {
 	const ext = extname(name);
 
 	switch (ext) {
-	case '.ts':
-		return /\.d\.ts$/.test(name) ? ProjectFileType.Definition : ProjectFileType.TypeScript;
-	case '.tsx':
-		return ProjectFileType.TypeScript;
-	case '.html':
-		return ProjectFileType.HTML;
-	case '.css':
-		return ProjectFileType.CSS;
-	case '.json':
-		return ProjectFileType.JSON;
-	case '.xml':
-		return ProjectFileType.XML;
-	case '.md':
-		return ProjectFileType.Markdown;
-	default:
-		return ProjectFileType.PlainText;
+		case '.ts':
+			return /\.d\.ts$/.test(name) ? ProjectFileType.Definition : ProjectFileType.TypeScript;
+		case '.tsx':
+			return ProjectFileType.TypeScript;
+		case '.html':
+			return ProjectFileType.HTML;
+		case '.css':
+			return ProjectFileType.CSS;
+		case '.json':
+			return ProjectFileType.JSON;
+		case '.xml':
+			return ProjectFileType.XML;
+		case '.md':
+			return ProjectFileType.Markdown;
+		default:
+			return ProjectFileType.PlainText;
 	}
 }
 
@@ -180,22 +183,21 @@ function getProjectFileType(name: string): ProjectFileType {
  * @param parsedPackages a set of packages that have already been parsed for export
  * @return a flattened map of production and peer dependencies
  */
-async function getDependencies (packages: StringMap, parsedPackages: Set<string> = new Set()): Promise<StringMap> {
+async function getDependencies(packages: StringMap, parsedPackages: Set<string> = new Set()): Promise<StringMap> {
 	const dependencies: StringMap = {};
 
 	for (const packageName in packages) {
 		if (!parsedPackages.has(packageName)) {
 			parsedPackages.add(packageName);
-			verbose(indent(2), bold.blue('resolving'), ` dependencies for package "${ packageName }"`);
+			verbose(indent(2), bold.blue('resolving'), ` dependencies for package "${packageName}"`);
 
 			let packageJson: PackageJson;
 
 			try {
 				const packageJsonFileName = requireResolve(join(packageName, 'package.json'));
 				packageJson = JSON.parse(await getFile(packageJsonFileName));
-			}
-			catch (e) {
-				verbose(indent(2), bold.yellow('missing'), ` "${ join(packageName, 'package.json') }"`);
+			} catch (e) {
+				verbose(indent(2), bold.yellow('missing'), ` "${join(packageName, 'package.json')}"`);
 				continue;
 			}
 
@@ -205,19 +207,18 @@ async function getDependencies (packages: StringMap, parsedPackages: Set<string>
 				verbose(
 					indent(3),
 					bold.blue('depends'),
-					` on packages "${ Object.keys(packageJson.dependencies).join('", "') }"`
+					` on packages "${Object.keys(packageJson.dependencies).join('", "')}"`
 				);
 			}
 			if (packageJson.peerDependencies && Object.keys(packageJson.peerDependencies).length) {
 				verbose(
 					indent(3),
 					bold.blue('depends'),
-					` on peer packages "${ Object.keys(packageJson.peerDependencies).join('", "') }"`
+					` on peer packages "${Object.keys(packageJson.peerDependencies).join('", "')}"`
 				);
 			}
-		}
-		else {
-			verbose(indent(2), bold.blue('skipping'), ` dependencies for package "${ packageName }", already seen`);
+		} else {
+			verbose(indent(2), bold.blue('skipping'), ` dependencies for package "${packageName}", already seen`);
 		}
 	}
 
@@ -243,7 +244,10 @@ async function addDependencies(project: ProjectJson) {
 	verbose(indent(), bold.blue('resolving'), ` development dependecies:`);
 	packageSet.clear();
 	Object.assign(project.dependencies.development, project.package.devDependencies);
-	Object.assign(project.dependencies.development, await getDependencies(project.dependencies.development, packageSet));
+	Object.assign(
+		project.dependencies.development,
+		await getDependencies(project.dependencies.development, packageSet)
+	);
 }
 
 /**
@@ -255,13 +259,14 @@ async function addDependencies(project: ProjectJson) {
 async function addProjectFiles(project: ProjectJson, includeExtensions: string = 'ts,tsx,html,css,json,xml,md') {
 	if (project.tsconfig.include) {
 		const globs = await Promise.all(
-			project.tsconfig.include
-				.map((pattern) => getGlob(pattern.replace(/(\.d)?\.ts$/, `.{${ includeExtensions }}`)))
+			project.tsconfig.include.map((pattern) =>
+				getGlob(pattern.replace(/(\.d)?\.ts$/, `.{${includeExtensions}}`))
+			)
 		);
-		const files = (<string[]> []).concat(... globs);
+		const files = (<string[]>[]).concat(...globs);
 		const tasks = files.map(async (name) => {
 			const text = await getFile(name);
-			verbose(indent(), bold.blue('adding'), ` project file "${ name }"`);
+			verbose(indent(), bold.blue('adding'), ` project file "${name}"`);
 			project.files.push({
 				name,
 				text,
@@ -280,7 +285,7 @@ async function addProjectFiles(project: ProjectJson, includeExtensions: string =
 async function addTypesFiles(project: ProjectJson) {
 	if (project.tsconfig.compilerOptions && project.tsconfig.compilerOptions.types) {
 		const tasks = project.tsconfig.compilerOptions.types.map(async (packageName) => {
-			verbose(indent(), bold.blue('resolving'), ` types for package "${ packageName }"`);
+			verbose(indent(), bold.blue('resolving'), ` types for package "${packageName}"`);
 
 			const packageJsonFilename = relative(cwd(), requireResolve(join(packageName, 'package.json')));
 			const packageJson: PackageJson = JSON.parse(await getFile(packageJsonFilename));
@@ -291,23 +296,21 @@ async function addTypesFiles(project: ProjectJson) {
 
 			const typings = packageJson.typings || packageJson.types;
 			if (typings) {
-				const filename = relative(
-					cwd(),
-					requireResolve(normalize(join(packageName, typings)))
-				);
+				const filename = relative(cwd(), requireResolve(normalize(join(packageName, typings))));
 
 				project.environmentFiles.push(createProjectFile(filename, await getFile(filename)));
-				verbose(indent(), bold.blue('adding'), ` type file "${ filename }"`);
-			}
-			else {
-				log(indent(), bold.yellow('warn'), ` "${ packageJsonFilename }" does not contain type information`);
+				verbose(indent(), bold.blue('adding'), ` type file "${filename}"`);
+			} else {
+				log(indent(), bold.yellow('warn'), ` "${packageJsonFilename}" does not contain type information`);
 
-				try { /* try to find an index.d.ts file, since none specified in package.json */
+				try {
+					/* try to find an index.d.ts file, since none specified in package.json */
 					const filename = relative(cwd(), requireResolve(normalize(join(packageName, 'index.d.ts'))));
 					project.environmentFiles.push(createProjectFile(filename, await getFile(filename)));
-					verbose(indent(), bold.blue('adding'), ` type file "${ filename }"`);
+					verbose(indent(), bold.blue('adding'), ` type file "${filename}"`);
+				} catch (e) {
+					/* swallow error */
 				}
-				catch (e) { /* swallow error */ }
 			}
 		});
 
@@ -322,15 +325,14 @@ async function addTypesFiles(project: ProjectJson) {
  */
 async function addDefinitionFiles(project: ProjectJson) {
 	const files = await getGlob('node_modules/{@dojo,@types}/**/*.d.ts');
-	const tasks = files
-		.map(async (filename) => {
-			if (DOJO_EXCLUDE.test(filename)) {
-				return;
-			}
+	const tasks = files.map(async (filename) => {
+		if (DOJO_EXCLUDE.test(filename)) {
+			return;
+		}
 
-			project.environmentFiles.push(createProjectFile(filename, await getFile(filename)));
-			verbose(indent(), bold.blue('adding'), ` definition file "${ filename }"`);
-		});
+		project.environmentFiles.push(createProjectFile(filename, await getFile(filename)));
+		verbose(indent(), bold.blue('adding'), ` definition file "${filename}"`);
+	});
 
 	return Promise.all(tasks);
 }
@@ -342,9 +344,8 @@ async function addDefinitionFiles(project: ProjectJson) {
  */
 function setProjectIndex(project: ProjectJson, index = './src/index.html') {
 	if (!project.files.find(({ name }) => name === index)) {
-		log(indent(), bold.red('error'), ` unable to find index "${ index }" in project.`);
-	}
-	else {
+		log(indent(), bold.red('error'), ` unable to find index "${index}" in project.`);
+	} else {
 		project.index = index;
 	}
 }
@@ -361,7 +362,7 @@ export default async function exportProject({ content, index, out, project: root
 		const initialCwd = cwd();
 		chdir(root);
 		if (cwd() !== initialCwd) {
-			verbose(indent(), bold.blue('changing'), ` working directory to "${ root }"`);
+			verbose(indent(), bold.blue('changing'), ` working directory to "${root}"`);
 		}
 
 		const project = await createProject();
@@ -371,7 +372,7 @@ export default async function exportProject({ content, index, out, project: root
 		tasks.push(addTypesFiles(project));
 		tasks.push(addDefinitionFiles(project));
 		if (content) {
-			verbose(indent(), bold.blue('setting'), ` project file extensions to "${ content }"`);
+			verbose(indent(), bold.blue('setting'), ` project file extensions to "${content}"`);
 		}
 		tasks.push(addProjectFiles(project, content));
 		tasks.push(addDependencies(project));
@@ -380,13 +381,12 @@ export default async function exportProject({ content, index, out, project: root
 		setProjectIndex(project, index);
 
 		/* write out project bundle file */
-		const outfilename = `${ (project.package.name || 'bundle').replace(/[\/\\]/, '-') }.project.json`;
+		const outfilename = `${(project.package.name || 'bundle').replace(/[\/\\]/, '-')}.project.json`;
 		const outfile = relative(cwd(), normalize(join(initialCwd, out, outfilename)));
 
 		await setFile(outfile, JSON.stringify(project));
-		log(indent(), bold.green('exported'), ` to "${ relative(initialCwd, outfile) }"\n`);
-	}
-	catch (e) {
+		log(indent(), bold.green('exported'), ` to "${relative(initialCwd, outfile)}"\n`);
+	} catch (e) {
 		const stack: string[] = e.stack.split('\n');
 		log(indent(), bold.red('errored'), ' ', stack.shift());
 		log(stack.join('\n'), '\n');

--- a/src/interfaces/dojorc.d.ts
+++ b/src/interfaces/dojorc.d.ts
@@ -1,15 +1,15 @@
 export interface BuildWebpackJson {
-	'locale'?: string;
-	'messageBundles'?: string | string[];
-	'supportedLocales'?: string | string[];
-	'watch'?: boolean;
-	'port'?: number;
-	'element'?: string;
-	'elementPrefix'?: string;
-	'withTests'?: boolean;
-	'debug'?: boolean;
-	'disableLazyWidgetDetection'?: boolean;
-	'bundles'?: { [bundle: string]: string[] };
+	locale?: string;
+	messageBundles?: string | string[];
+	supportedLocales?: string | string[];
+	watch?: boolean;
+	port?: number;
+	element?: string;
+	elementPrefix?: string;
+	withTests?: boolean;
+	debug?: boolean;
+	disableLazyWidgetDetection?: boolean;
+	bundles?: { [bundle: string]: string[] };
 }
 
 export interface DojoRcJson {

--- a/src/interfaces/interfaces.d.ts
+++ b/src/interfaces/interfaces.d.ts
@@ -1,5 +1,7 @@
 declare module 'resolve-cwd' {
-	module resolve { }
+	namespace resolve {
+
+	}
 	function resolve(path: string): string;
 	export = resolve;
 }

--- a/src/interfaces/package.json.d.ts
+++ b/src/interfaces/package.json.d.ts
@@ -2,9 +2,9 @@
  * A person who has been involved in creating or maintaining this package
  */
 export interface Person {
-	'name': string;
-	'url'?: string;
-	'email'?: string;
+	name: string;
+	url?: string;
+	email?: string;
 	[k: string]: any;
 }
 export type ScriptsPublishAfter = string;
@@ -25,273 +25,275 @@ export interface CoreProperties {
 	/**
 	 * The name of the package.
 	 */
-	'name'?: string;
+	name?: string;
 	/**
 	 * Version must be parseable by node-semver, which is bundled with npm as a dependency.
 	 */
-	'version'?: string;
+	version?: string;
 	/**
 	 * This helps people discover your package, as it's listed in 'npm search'.
 	 */
-	'description'?: string;
+	description?: string;
 	/**
 	 * This helps people discover your package as it's listed in 'npm search'.
 	 */
-	'keywords'?: string[];
+	keywords?: string[];
 	/**
 	 * The url to the project homepage.
 	 */
-	'homepage'?: string;
+	homepage?: string;
 	/**
 	 * The url to your project's issue tracker and / or the email address to which issues should be reported. These are helpful for people who encounter issues with your package.
 	 */
-	'bugs'?: {
+	bugs?: {
 		/**
 		 * The url to your project's issue tracker.
 		 */
-		'url'?: string;
+		url?: string;
 		/**
 		 * The email address to which issues should be reported.
 		 */
-		'email'?: string;
+		email?: string;
 		[k: string]: any;
 	};
 	/**
 	 * You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it.
 	 */
-	'license'?: string;
+	license?: string;
 	/**
 	 * You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it.
 	 */
-	'licenses'?: {
-		'type'?: string;
-		'url'?: string;
+	licenses?: {
+		type?: string;
+		url?: string;
 		[k: string]: any;
 	}[];
 	/**
 	 * A person who has been involved in creating or maintaining this package
 	 */
-	'author'?: Person;
+	author?: Person;
 	/**
 	 * A list of people who contributed to this package.
 	 */
-	'contributors'?: Person[];
+	contributors?: Person[];
 	/**
 	 * A list of people who maintains this package.
 	 */
-	'maintainers'?: Person[];
+	maintainers?: Person[];
 	/**
 	 * The 'files' field is an array of files to include in your project. If you name a folder in the array, then it will also include the files inside that folder.
 	 */
-	'files'?: string[];
+	files?: string[];
 	/**
 	 * The main field is a module ID that is the primary entry point to your program.
 	 */
-	'main'?: string;
-	'bin'?: {
+	main?: string;
+	bin?: {
 		[k: string]: string;
 	};
 	/**
 	 * Specify either a single file or an array of filenames to put in place for the man program to find.
 	 */
-	'man'?: any[] | string;
-	'directories'?: {
+	man?: any[] | string;
+	directories?: {
 		/**
 		 * If you specify a 'bin' directory, then all the files in that folder will be used as the 'bin' hash.
 		 */
-		'bin'?: string;
+		bin?: string;
 		/**
 		 * Put markdown files in here. Eventually, these will be displayed nicely, maybe, someday.
 		 */
-		'doc'?: string;
+		doc?: string;
 		/**
 		 * Put example scripts in here. Someday, it might be exposed in some clever way.
 		 */
-		'example'?: string;
+		example?: string;
 		/**
 		 * Tell people where the bulk of your library is. Nothing special is done with the lib folder in any way, but it's useful meta info.
 		 */
-		'lib'?: string;
+		lib?: string;
 		/**
 		 * A folder that is full of man pages. Sugar to generate a 'man' array by walking the folder.
 		 */
-		'man'?: string;
-		'test'?: string;
+		man?: string;
+		test?: string;
 		[k: string]: any;
 	};
 	/**
 	 * Specify the place where your code lives. This is helpful for people who want to contribute.
 	 */
-	'repository'?: {
-		'type'?: string;
-		'url'?: string;
+	repository?: {
+		type?: string;
+		url?: string;
 		[k: string]: any;
 	};
 	/**
 	 * The 'scripts' member is an object hash of script commands that are run at various times in the lifecycle of your package. The key is the lifecycle event, and the value is the command to run at that point.
 	 */
-	'scripts'?: {
+	scripts?: {
 		/**
 		 * Run BEFORE the package is published (Also run on local npm install without any arguments)
 		 */
-		'prepublish'?: string;
+		prepublish?: string;
 		/**
 		 * Run AFTER the package is published
 		 */
-		'publish'?: ScriptsPublishAfter;
+		publish?: ScriptsPublishAfter;
 		/**
 		 * Run AFTER the package is published
 		 */
-		'postpublish'?: ScriptsPublishAfter;
+		postpublish?: ScriptsPublishAfter;
 		/**
 		 * Run BEFORE the package is installed
 		 */
-		'preinstall'?: string;
+		preinstall?: string;
 		/**
 		 * Run AFTER the package is installed
 		 */
-		'install'?: ScriptsInstallAfter;
+		install?: ScriptsInstallAfter;
 		/**
 		 * Run AFTER the package is installed
 		 */
-		'postinstall'?: ScriptsInstallAfter;
+		postinstall?: ScriptsInstallAfter;
 		/**
 		 * Run BEFORE the package is uninstalled
 		 */
-		'preuninstall'?: ScriptsUninstallBefore;
+		preuninstall?: ScriptsUninstallBefore;
 		/**
 		 * Run BEFORE the package is uninstalled
 		 */
-		'uninstall'?: ScriptsUninstallBefore;
+		uninstall?: ScriptsUninstallBefore;
 		/**
 		 * Run AFTER the package is uninstalled
 		 */
-		'postuninstall'?: string;
+		postuninstall?: string;
 		/**
 		 * Run BEFORE bump the package version
 		 */
-		'preversion'?: ScriptsVersionBefore;
+		preversion?: ScriptsVersionBefore;
 		/**
 		 * Run BEFORE bump the package version
 		 */
-		'version'?: ScriptsVersionBefore;
+		version?: ScriptsVersionBefore;
 		/**
 		 * Run AFTER bump the package version
 		 */
-		'postversion'?: string;
+		postversion?: string;
 		/**
 		 * Run by the 'npm test' command
 		 */
-		'pretest'?: ScriptsTest;
+		pretest?: ScriptsTest;
 		/**
 		 * Run by the 'npm test' command
 		 */
-		'test'?: ScriptsTest;
+		test?: ScriptsTest;
 		/**
 		 * Run by the 'npm test' command
 		 */
-		'posttest'?: ScriptsTest;
+		posttest?: ScriptsTest;
 		/**
 		 * Run by the 'npm stop' command
 		 */
-		'prestop'?: ScriptsStop;
+		prestop?: ScriptsStop;
 		/**
 		 * Run by the 'npm stop' command
 		 */
-		'stop'?: ScriptsStop;
+		stop?: ScriptsStop;
 		/**
 		 * Run by the 'npm stop' command
 		 */
-		'poststop'?: ScriptsStop;
+		poststop?: ScriptsStop;
 		/**
 		 * Run by the 'npm start' command
 		 */
-		'prestart'?: ScriptsStart;
+		prestart?: ScriptsStart;
 		/**
 		 * Run by the 'npm start' command
 		 */
-		'start'?: ScriptsStart;
+		start?: ScriptsStart;
 		/**
 		 * Run by the 'npm start' command
 		 */
-		'poststart'?: ScriptsStart;
+		poststart?: ScriptsStart;
 		/**
 		 * Run by the 'npm restart' command. Note: 'npm restart' will run the stop and start scripts if no restart script is provided.
 		 */
-		'prerestart'?: ScriptsRestart;
+		prerestart?: ScriptsRestart;
 		/**
 		 * Run by the 'npm restart' command. Note: 'npm restart' will run the stop and start scripts if no restart script is provided.
 		 */
-		'restart'?: ScriptsRestart;
+		restart?: ScriptsRestart;
 		/**
 		 * Run by the 'npm restart' command. Note: 'npm restart' will run the stop and start scripts if no restart script is provided.
 		 */
-		'postrestart'?: ScriptsRestart;
+		postrestart?: ScriptsRestart;
 		[k: string]: string | undefined;
 	};
 	/**
 	 * A 'config' hash can be used to set configuration parameters used in package scripts that persist across upgrades.
 	 */
-	'config'?: any;
+	config?: any;
 	/**
 	 * Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.
 	 */
-	'dependencies'?: Dependency;
+	dependencies?: Dependency;
 	/**
 	 * Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.
 	 */
-	'devDependencies'?: Dependency;
+	devDependencies?: Dependency;
 	/**
 	 * Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.
 	 */
-	'optionalDependencies'?: Dependency;
+	optionalDependencies?: Dependency;
 	/**
 	 * Dependencies are specified with a simple hash of package name to version range. The version range is a string which has one or more space-separated descriptors. Dependencies can also be identified with a tarball or git URL.
 	 */
-	'peerDependencies'?: Dependency;
-	'engines'?: {
+	peerDependencies?: Dependency;
+	engines?: {
 		[k: string]: string;
 	};
-	'engineStrict'?: boolean;
+	engineStrict?: boolean;
 	/**
 	 * You can specify which operating systems your module will run on
 	 */
-	'os'?: string[];
+	os?: string[];
 	/**
 	 * If your code only runs on certain cpu architectures, you can specify which ones.
 	 */
-	'cpu'?: string[];
+	cpu?: string[];
 	/**
 	 * If your package is primarily a command-line application that should be installed globally, then set this value to true to provide a warning if it is installed locally.
 	 */
-	'preferGlobal'?: boolean;
+	preferGlobal?: boolean;
 	/**
 	 * If set to true, then npm will refuse to publish it.
 	 */
-	'private'?: boolean;
-	'publishConfig'?: any;
-	'dist'?: {
-		'shasum'?: string;
-		'tarball'?: string;
+	private?: boolean;
+	publishConfig?: any;
+	dist?: {
+		shasum?: string;
+		tarball?: string;
 		[k: string]: any;
 	};
-	'readme'?: string;
+	readme?: string;
 	[k: string]: any;
 }
 export interface JspmDefinition {
-	'jspm'?: CoreProperties;
+	jspm?: CoreProperties;
 	[k: string]: any;
 }
 export interface TypingsDefinition {
-	'typings'?: string;
-	'types'?: string;
+	typings?: string;
+	types?: string;
 	[k: string]: any;
 }
 export type BundledDependency = string[];
-export type JsonSchemaForNpmPackageJsonFiles = CoreProperties & JspmDefinition & TypingsDefinition & {
-	/**
-	 * Array of package names that will be bundled when publishing the package.
-	 */
-	'bundleDependencies'?: BundledDependency;
-	[k: string]: any;
-};
+export type JsonSchemaForNpmPackageJsonFiles = CoreProperties &
+	JspmDefinition &
+	TypingsDefinition & {
+		/**
+		 * Array of package names that will be bundled when publishing the package.
+		 */
+		bundleDependencies?: BundledDependency;
+		[k: string]: any;
+	};

--- a/src/interfaces/project.json.d.ts
+++ b/src/interfaces/project.json.d.ts
@@ -4,7 +4,6 @@ import { JsonSchemaForTheTsLintConfigurationFiles as TslintJson } from './tslint
 import { DojoRcJson } from './dojorc';
 
 export interface ProjectJson {
-
 	/**
 	 * The package dependencies for the project, either `production` or `development`
 	 */
@@ -14,14 +13,14 @@ export interface ProjectJson {
 		 */
 		production: {
 			[pkg: string]: string;
-		},
+		};
 
 		/**
 		 * A map of development dependencies, where the package name is the key and the value is the semver of the package
 		 */
 		development: {
 			[pkg: string]: string;
-		}
+		};
 	};
 
 	/**

--- a/src/interfaces/tsconfig.json.d.ts
+++ b/src/interfaces/tsconfig.json.d.ts
@@ -2,268 +2,292 @@ export interface CompilerOptionsDefinition {
 	/**
 	 * Instructs the TypeScript compiler how to compile .ts files.
 	 */
-	'compilerOptions'?: {
+	compilerOptions?: {
 		/**
 		 * The character set of the input files.
 		 */
-		'charset'?: string;
+		charset?: string;
 		/**
 		 * Generates corresponding d.ts files.
 		 */
-		'declaration'?: boolean;
+		declaration?: boolean;
 		/**
 		 * Specify output directory for generated declaration files. Requires TypeScript version 2.0 or later.
 		 */
-		'declarationDir'?: string;
+		declarationDir?: string;
 		/**
 		 * Show diagnostic information.
 		 */
-		'diagnostics'?: boolean;
+		diagnostics?: boolean;
 		/**
 		 * Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.
 		 */
-		'emitBOM'?: boolean;
+		emitBOM?: boolean;
 		/**
 		 * Emit a single file with source maps instead of having a separate file.
 		 */
-		'inlineSourceMap'?: boolean;
+		inlineSourceMap?: boolean;
 		/**
 		 * Emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap to be set.
 		 */
-		'inlineSources'?: boolean;
+		inlineSources?: boolean;
 		/**
 		 * Specify JSX code generation: 'preserve', 'react', or 'react-native'.
 		 */
-		'jsx'?: 'preserve' | 'react' | 'react-native';
+		jsx?: 'preserve' | 'react' | 'react-native';
 		/**
 		 * Specifies the object invoked for createElement and __spread when targeting 'react' JSX emit.
 		 */
-		'reactNamespace'?: string;
+		reactNamespace?: string;
 		/**
 		 * Print names of files part of the compilation.
 		 */
-		'listFiles'?: boolean;
+		listFiles?: boolean;
 		/**
 		 * The locale to use to show error messages, e.g. en-us.
 		 */
-		'locale'?: string;
+		locale?: string;
 		/**
 		 * Specifies the location where debugger should locate map files instead of generated locations
 		 */
-		'mapRoot'?: string;
+		mapRoot?: string;
 		/**
 		 * Specify module code generation: 'none', 'CommonJS', 'Amd', 'System', 'UMD', or 'es2015'.
 		 */
-		'module'?: 'commonjs' | 'amd' | 'umd' | 'system' | 'es6' | 'es2015' | 'none';
+		module?: 'commonjs' | 'amd' | 'umd' | 'system' | 'es6' | 'es2015' | 'none';
 		/**
 		 * Specifies the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).
 		 */
-		'newLine'?: 'CRLF' | 'LF';
+		newLine?: 'CRLF' | 'LF';
 		/**
 		 * Do not emit output.
 		 */
-		'noEmit'?: boolean;
+		noEmit?: boolean;
 		/**
 		 * Do not generate custom helper functions like __extends in compiled output.
 		 */
-		'noEmitHelpers'?: boolean;
+		noEmitHelpers?: boolean;
 		/**
 		 * Do not emit outputs if any type checking errors were reported.
 		 */
-		'noEmitOnError'?: boolean;
+		noEmitOnError?: boolean;
 		/**
 		 * Warn on expressions and declarations with an implied 'any' type.
 		 */
-		'noImplicitAny'?: boolean;
+		noImplicitAny?: boolean;
 		/**
 		 * Raise error on 'this' expressions with an implied any type.
 		 */
-		'noImplicitThis'?: boolean;
+		noImplicitThis?: boolean;
 		/**
 		 * Report errors on unused locals. Requires TypeScript version 2.0 or later.
 		 */
-		'noUnusedLocals'?: boolean;
+		noUnusedLocals?: boolean;
 		/**
 		 * Report errors on unused parameters. Requires TypeScript version 2.0 or later.
 		 */
-		'noUnusedParameters'?: boolean;
+		noUnusedParameters?: boolean;
 		/**
 		 * Do not include the default library file (lib.d.ts).
 		 */
-		'noLib'?: boolean;
+		noLib?: boolean;
 		/**
 		 * Do not add triple-slash references or module import targets to the list of compiled files.
 		 */
-		'noResolve'?: boolean;
-		'skipDefaultLibCheck'?: boolean;
+		noResolve?: boolean;
+		skipDefaultLibCheck?: boolean;
 		/**
 		 * Skip type checking of declaration files. Requires TypeScript version 2.0 or later.
 		 */
-		'skipLibCheck'?: boolean;
+		skipLibCheck?: boolean;
 		/**
 		 * Concatenate and emit output to single file.
 		 */
-		'outFile'?: string;
+		outFile?: string;
 		/**
 		 * Redirect output structure to the directory.
 		 */
-		'outDir'?: string;
+		outDir?: string;
 		/**
 		 * Do not erase const enum declarations in generated code.
 		 */
-		'preserveConstEnums'?: boolean;
+		preserveConstEnums?: boolean;
 		/**
 		 * Stylize errors and messages using color and context (experimental).
 		 */
-		'pretty'?: boolean;
+		pretty?: boolean;
 		/**
 		 * Do not emit comments to output.
 		 */
-		'removeComments'?: boolean;
+		removeComments?: boolean;
 		/**
 		 * Specifies the root directory of input files. Use to control the output directory structure with --outDir.
 		 */
-		'rootDir'?: string;
+		rootDir?: string;
 		/**
 		 * Unconditionally emit imports for unresolved files.
 		 */
-		'isolatedModules'?: boolean;
+		isolatedModules?: boolean;
 		/**
 		 * Generates corresponding '.map' file.
 		 */
-		'sourceMap'?: boolean;
+		sourceMap?: boolean;
 		/**
 		 * Specifies the location where debugger should locate TypeScript files instead of source locations.
 		 */
-		'sourceRoot'?: string;
+		sourceRoot?: string;
 		/**
 		 * Suppress excess property checks for object literals.
 		 */
-		'suppressExcessPropertyErrors'?: boolean;
+		suppressExcessPropertyErrors?: boolean;
 		/**
 		 * Suppress noImplicitAny errors for indexing objects lacking index signatures.
 		 */
-		'suppressImplicitAnyIndexErrors'?: boolean;
+		suppressImplicitAnyIndexErrors?: boolean;
 		/**
 		 * Do not emit declarations for code that has an '@internal' annotation.
 		 */
-		'stripInternal'?: boolean;
+		stripInternal?: boolean;
 		/**
 		 * Specify ECMAScript target version. Permitted values are 'es3', 'es5', 'es2015', 'es2016', 'es2017' or 'esnext'.
 		 */
-		'target'?: 'es3' | 'es5' | 'es2015' | 'es2016' | 'es2017' | 'esnext' | any;
+		target?: 'es3' | 'es5' | 'es2015' | 'es2016' | 'es2017' | 'esnext' | any;
 		/**
 		 * Watch input files.
 		 */
-		'watch'?: boolean;
+		watch?: boolean;
 		/**
 		 * Enables experimental support for ES7 decorators.
 		 */
-		'experimentalDecorators'?: boolean;
+		experimentalDecorators?: boolean;
 		/**
 		 * Emit design-type metadata for decorated declarations in source.
 		 */
-		'emitDecoratorMetadata'?: boolean;
+		emitDecoratorMetadata?: boolean;
 		/**
 		 * Specifies module resolution strategy: 'node' (Node) or 'classic' (TypeScript pre 1.6) .
 		 */
-		'moduleResolution'?: string;
+		moduleResolution?: string;
 		/**
 		 * Do not report errors on unused labels.
 		 */
-		'allowUnusedLabels'?: boolean;
+		allowUnusedLabels?: boolean;
 		/**
 		 * Report error when not all code paths in function return a value.
 		 */
-		'noImplicitReturns'?: boolean;
+		noImplicitReturns?: boolean;
 		/**
 		 * Report errors for fallthrough cases in switch statement.
 		 */
-		'noFallthroughCasesInSwitch'?: boolean;
+		noFallthroughCasesInSwitch?: boolean;
 		/**
 		 * Do not report errors on unreachable code.
 		 */
-		'allowUnreachableCode'?: boolean;
+		allowUnreachableCode?: boolean;
 		/**
 		 * Disallow inconsistently-cased references to the same file.
 		 */
-		'forceConsistentCasingInFileNames'?: boolean;
+		forceConsistentCasingInFileNames?: boolean;
 		/**
 		 * Base directory to resolve non-relative module names.
 		 */
-		'baseUrl'?: string;
+		baseUrl?: string;
 		/**
 		 * Specify path mapping to be computed relative to baseUrl option.
 		 */
-		'paths'?: Object;
+		paths?: Object;
 		/**
 		 * Specify list of root directories to be used when resolving modules.
 		 */
-		'rootDirs'?: string[];
+		rootDirs?: string[];
 		/**
 		 * Specify list of directories for type definition files to be included. Requires TypeScript version 2.0 or later.
 		 */
-		'typeRoots'?: string[];
+		typeRoots?: string[];
 		/**
 		 * Type declaration files to be included in compilation. Requires TypeScript version 2.0 or later.
 		 */
-		'types'?: string[];
+		types?: string[];
 		/**
 		 * Enable tracing of the name resolution process.
 		 */
-		'traceResolution'?: boolean;
+		traceResolution?: boolean;
 		/**
 		 * Allow javascript files to be compiled.
 		 */
-		'allowJs'?: boolean;
+		allowJs?: boolean;
 		/**
 		 * Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
 		 */
-		'allowSyntheticDefaultImports'?: boolean;
+		allowSyntheticDefaultImports?: boolean;
 		/**
 		 * Do not emit 'use strict' directives in module output.
 		 */
-		'noImplicitUseStrict'?: boolean;
+		noImplicitUseStrict?: boolean;
 		/**
 		 * Enable to list all emitted files. Requires TypeScript version 2.0 or later.
 		 */
-		'listEmittedFiles'?: boolean;
+		listEmittedFiles?: boolean;
 		/**
 		 * Specify library file to be included in the compilation. Requires TypeScript version 2.0 or later.
 		 */
-		'lib'?: ('es5' | 'es6' | 'es2015' | 'es7' | 'es2016' | 'es2017' | 'esnext' | 'dom' | 'dom.iterable' | 'webworker' | 'scripthost' | 'es2015.core' | 'es2015.collection' | 'es2015.generator' | 'es2015.iterable' | 'es2015.promise' | 'es2015.proxy' | 'es2015.reflect' | 'es2015.symbol' | 'es2015.symbol.wellknown' | 'es2016.array.include' | 'es2017.object' | 'es2017.sharedmemory' | 'esnext.asynciterable')[];
+		lib?: (
+			| 'es5'
+			| 'es6'
+			| 'es2015'
+			| 'es7'
+			| 'es2016'
+			| 'es2017'
+			| 'esnext'
+			| 'dom'
+			| 'dom.iterable'
+			| 'webworker'
+			| 'scripthost'
+			| 'es2015.core'
+			| 'es2015.collection'
+			| 'es2015.generator'
+			| 'es2015.iterable'
+			| 'es2015.promise'
+			| 'es2015.proxy'
+			| 'es2015.reflect'
+			| 'es2015.symbol'
+			| 'es2015.symbol.wellknown'
+			| 'es2016.array.include'
+			| 'es2017.object'
+			| 'es2017.sharedmemory'
+			| 'esnext.asynciterable')[];
 		/**
 		 * Enable strict null checks. Requires TypeScript version 2.0 or later.
 		 */
-		'strictNullChecks'?: boolean;
+		strictNullChecks?: boolean;
 		/**
 		 * The maximum dependency depth to search under node_modules and load JavaScript files. Only applicable with --allowJs.
 		 */
-		'maxNodeModuleJsDepth'?: number;
+		maxNodeModuleJsDepth?: number;
 		/**
 		 * Import emit helpers (e.g. '__extends', '__rest', etc..) from tslib. Requires TypeScript version 2.1 or later.
 		 */
-		'importHelpers'?: boolean;
+		importHelpers?: boolean;
 		/**
 		 * Specify the JSX factory function to use when targeting react JSX emit, e.g. 'React.createElement' or 'h'. Requires TypeScript version 2.1 or later.
 		 */
-		'jsxFactory'?: string;
+		jsxFactory?: string;
 		/**
 		 * Parse in strict mode and emit 'use strict' for each source file. Requires TypeScript version 2.1 or later.
 		 */
-		'alwaysStrict'?: boolean;
+		alwaysStrict?: boolean;
 		/**
 		 * Enable all strict type checking options. Requires TypeScript version 2.3 or later.
 		 */
-		'strict'?: boolean;
+		strict?: boolean;
 		/**
 		 * Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. Requires TypeScript version 2.3 or later.
 		 */
-		'downlevelIteration'?: boolean;
+		downlevelIteration?: boolean;
 		/**
 		 * Report errors in .js files. Requires TypeScript version 2.3 or later.
 		 */
-		'checkJs'?: boolean;
+		checkJs?: boolean;
 		[k: string]: any;
 	};
 	[k: string]: any;
@@ -272,26 +296,26 @@ export interface CompileOnSaveDefinition {
 	/**
 	 * Enable Compile-on-Save for this project.
 	 */
-	'compileOnSave'?: boolean;
+	compileOnSave?: boolean;
 	[k: string]: any;
 }
 export interface TypeAcquisitionDefinition {
 	/**
 	 * Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.
 	 */
-	'typeAcquisition'?: {
+	typeAcquisition?: {
 		/**
 		 * Enable auto type acquisition
 		 */
-		'enable'?: boolean;
+		enable?: boolean;
 		/**
 		 * Specifies a list of type declarations to be included in auto type acquisition. Ex. ['jquery', 'lodash']
 		 */
-		'include'?: string[];
+		include?: string[];
 		/**
 		 * Specifies a list of type declarations to be excluded from auto type acquisition. Ex. ['jquery', 'lodash']
 		 */
-		'exclude'?: string[];
+		exclude?: string[];
 		[k: string]: any;
 	};
 	[k: string]: any;
@@ -300,28 +324,33 @@ export interface ExtendsDefinition {
 	/**
 	 * Path to base configuration file to inherit from. Requires TypeScript version 2.1 or later.
 	 */
-	'extends'?: string;
+	extends?: string;
 	[k: string]: any;
 }
 export interface FilesDefinition {
 	/**
 	 * If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.
 	 */
-	'files'?: string[];
+	files?: string[];
 	[k: string]: any;
 }
 export interface ExcludeDefinition {
 	/**
 	 * Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.
 	 */
-	'exclude'?: string[];
+	exclude?: string[];
 	[k: string]: any;
 }
 export interface IncludeDefinition {
 	/**
 	 * Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.
 	 */
-	'include'?: string[];
+	include?: string[];
 	[k: string]: any;
 }
-export type JsonSchemaForTheTypeScriptCompilersConfigurationFile = CompilerOptionsDefinition & CompileOnSaveDefinition & TypeAcquisitionDefinition & ExtendsDefinition & FilesDefinition & IncludeDefinition;
+export type JsonSchemaForTheTypeScriptCompilersConfigurationFile = CompilerOptionsDefinition &
+	CompileOnSaveDefinition &
+	TypeAcquisitionDefinition &
+	ExtendsDefinition &
+	FilesDefinition &
+	IncludeDefinition;

--- a/src/interfaces/tslint.json.d.ts
+++ b/src/interfaces/tslint.json.d.ts
@@ -6,7 +6,7 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces vertical alignment for parameters, arguments and/or statements
 	 */
-	'align'?: (true | false | 'parameters' | 'arguments' | 'statements')[];
+	align?: (true | false | 'parameters' | 'arguments' | 'statements')[];
 	/**
 	 * Requires using either 'T[]' or 'Array<T>' for arrays
 	 */
@@ -18,7 +18,7 @@ export interface Ruledefinitions {
 	/**
 	 * Bans the use of specific functions or global methods
 	 */
-	'ban'?: boolean | any[];
+	ban?: boolean | any[];
 	/**
 	 * Enforces PascalCased class and interface names
 	 */
@@ -26,16 +26,22 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces rules for single-line comments
 	 */
-	'comment-format'?: (true | false | 'check-space' | 'check-lowercase' | 'check-uppercase' | {
-		/**
-		 * Words that will be ignored at the beginning of comment
-		 */
-		'ignore-words'?: string[];
-		/**
-		 * RegExp pattern that will be ignored at the beginning of comment
-		 */
-		'ignore-pattern'?: string;
-	})[];
+	'comment-format'?: (
+		| true
+		| false
+		| 'check-space'
+		| 'check-lowercase'
+		| 'check-uppercase'
+		| {
+				/**
+				 * Words that will be ignored at the beginning of comment
+				 */
+				'ignore-words'?: string[];
+				/**
+				 * RegExp pattern that will be ignored at the beginning of comment
+				 */
+				'ignore-pattern'?: string;
+			})[];
 	/**
 	 * Enforces documentation for important items be filled out
 	 */
@@ -59,7 +65,7 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces braces for if/for/do/while statements
 	 */
-	'curly'?: boolean;
+	curly?: boolean;
 	/**
 	 * Enforces a threshold of cyclomatic complexity
 	 */
@@ -83,7 +89,7 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces the file to end with a newline
 	 */
-	'eofline'?: boolean;
+	eofline?: boolean;
 	/**
 	 * Enforces a certain header comment for all files, matched by a regular expression
 	 */
@@ -91,11 +97,11 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces a for...in statement to be filtered with an if statement
 	 */
-	'forin'?: boolean;
+	forin?: boolean;
 	/**
 	 * Enforces consistent indentation levels
 	 */
-	'indent'?: (boolean | number | string)[];
+	indent?: (boolean | number | string)[];
 	/**
 	 * Enforces the rule that interface names must or must not begin with a capital 'I'
 	 */
@@ -163,7 +169,28 @@ export interface Ruledefinitions {
 	/**
 	 * Disallows access to the specified functions on console
 	 */
-	'no-console'?: (true | false | 'assert' | 'count' | 'debug' | 'dir' | 'dirxml' | 'error' | 'group' | 'groupCollapsed' | 'groupEnd' | 'info' | 'log' | 'profile' | 'profileEnd' | 'table' | 'time' | 'timeEnd' | 'timeStamp' | 'trace' | 'warn')[];
+	'no-console'?: (
+		| true
+		| false
+		| 'assert'
+		| 'count'
+		| 'debug'
+		| 'dir'
+		| 'dirxml'
+		| 'error'
+		| 'group'
+		| 'groupCollapsed'
+		| 'groupEnd'
+		| 'info'
+		| 'log'
+		| 'profile'
+		| 'profileEnd'
+		| 'table'
+		| 'time'
+		| 'timeEnd'
+		| 'timeStamp'
+		| 'trace'
+		| 'warn')[];
 	/**
 	 * Disallows access to the constructors of String, Number and Boolean
 	 */
@@ -287,7 +314,14 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces the specified tokens to be on the same line as the expression preceding it
 	 */
-	'one-line'?: (true | false | 'check-open-brace' | 'check-catch' | 'check-finally' | 'check-else' | 'check-whitespace')[];
+	'one-line'?: (
+		| true
+		| false
+		| 'check-open-brace'
+		| 'check-catch'
+		| 'check-finally'
+		| 'check-else'
+		| 'check-whitespace')[];
 	/**
 	 * Disallows multiple variable definitions in the same declaration statement
 	 */
@@ -307,11 +341,11 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces consistent single or double quoted string literals
 	 */
-	'quotemark'?: (true | false | 'double' | 'single' | 'jsx-double' | 'jsx-single' | 'avoid-escape')[];
+	quotemark?: (true | false | 'double' | 'single' | 'jsx-double' | 'jsx-single' | 'avoid-escape')[];
 	/**
 	 * Enforces the radix parameter of parseInt
 	 */
-	'radix'?: boolean;
+	radix?: boolean;
 	/**
 	 * When adding two variables, operands must both be of type number or of type string
 	 */
@@ -319,7 +353,7 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces semicolons at the end of every statement
 	 */
-	'semicolon'?: (true | false | 'always' | 'never' | 'ignore-bound-class-methods' | 'ignore-interfaces')[];
+	semicolon?: (true | false | 'always' | 'never' | 'ignore-bound-class-methods' | 'ignore-interfaces')[];
 	/**
 	 * Enforces a default case in switch statements
 	 */
@@ -335,7 +369,15 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces type definitions to exist
 	 */
-	'typedef'?: (true | false | 'call-signature' | 'parameter' | 'arrow-parameter' | 'property-declaration' | 'variable-declaration' | 'member-variable-declaration')[];
+	typedef?: (
+		| true
+		| false
+		| 'call-signature'
+		| 'parameter'
+		| 'arrow-parameter'
+		| 'property-declaration'
+		| 'variable-declaration'
+		| 'member-variable-declaration')[];
 	/**
 	 * Enforces spacing whitespace for type definitions
 	 */
@@ -351,14 +393,23 @@ export interface Ruledefinitions {
 	/**
 	 * Enforces spacing whitespace
 	 */
-	'whitespace'?: (true | false | 'check-branch' | 'check-decl' | 'check-operator' | 'check-module' | 'check-separator' | 'check-type' | 'check-typecast')[];
+	whitespace?: (
+		| true
+		| false
+		| 'check-branch'
+		| 'check-decl'
+		| 'check-operator'
+		| 'check-module'
+		| 'check-separator'
+		| 'check-type'
+		| 'check-typecast')[];
 	[k: string]: any;
 }
 export interface Jsruledefinitions {
 	/**
 	 * Enforces vertical alignment for parameters, arguments and/or statements
 	 */
-	'align'?: (true | false | 'parameters' | 'arguments' | 'statements')[];
+	align?: (true | false | 'parameters' | 'arguments' | 'statements')[];
 	/**
 	 * Requires parentheses around the parameters of arrow function definitions
 	 */
@@ -366,7 +417,7 @@ export interface Jsruledefinitions {
 	/**
 	 * Bans the use of specific functions or global methods
 	 */
-	'ban'?: boolean | any[];
+	ban?: boolean | any[];
 	/**
 	 * Enforces PascalCased class and interface names
 	 */
@@ -398,7 +449,7 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces braces for if/for/do/while statements
 	 */
-	'curly'?: boolean;
+	curly?: boolean;
 	/**
 	 * Enforces a threshold of cyclomatic complexity
 	 */
@@ -422,7 +473,7 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces the file to end with a newline
 	 */
-	'eofline'?: boolean;
+	eofline?: boolean;
 	/**
 	 * Enforces a certain header comment for all files, matched by a regular expression
 	 */
@@ -430,11 +481,11 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces a for...in statement to be filtered with an if statement
 	 */
-	'forin'?: boolean;
+	forin?: boolean;
 	/**
 	 * Enforces consistent indentation levels
 	 */
-	'indent'?: (boolean | number | string)[];
+	indent?: (boolean | number | string)[];
 	/**
 	 * Enforces basic format rules for jsdoc comments
 	 */
@@ -482,7 +533,28 @@ export interface Jsruledefinitions {
 	/**
 	 * Disallows access to the specified functions on console
 	 */
-	'no-console'?: (true | false | 'assert' | 'count' | 'debug' | 'dir' | 'dirxml' | 'error' | 'group' | 'groupCollapsed' | 'groupEnd' | 'info' | 'log' | 'profile' | 'profileEnd' | 'table' | 'time' | 'timeEnd' | 'timeStamp' | 'trace' | 'warn')[];
+	'no-console'?: (
+		| true
+		| false
+		| 'assert'
+		| 'count'
+		| 'debug'
+		| 'dir'
+		| 'dirxml'
+		| 'error'
+		| 'group'
+		| 'groupCollapsed'
+		| 'groupEnd'
+		| 'info'
+		| 'log'
+		| 'profile'
+		| 'profileEnd'
+		| 'table'
+		| 'time'
+		| 'timeEnd'
+		| 'timeStamp'
+		| 'trace'
+		| 'warn')[];
 	/**
 	 * Disallows access to the constructors of String, Number and Boolean
 	 */
@@ -578,7 +650,14 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces the specified tokens to be on the same line as the expression preceding it
 	 */
-	'one-line'?: (true | false | 'check-open-brace' | 'check-catch' | 'check-finally' | 'check-else' | 'check-whitespace')[];
+	'one-line'?: (
+		| true
+		| false
+		| 'check-open-brace'
+		| 'check-catch'
+		| 'check-finally'
+		| 'check-else'
+		| 'check-whitespace')[];
 	/**
 	 * Disallows multiple variable definitions in the same declaration statement
 	 */
@@ -598,11 +677,11 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces consistent single or double quoted string literals
 	 */
-	'quotemark'?: (true | false | 'double' | 'single' | 'jsx-double' | 'jsx-single' | 'avoid-escape')[];
+	quotemark?: (true | false | 'double' | 'single' | 'jsx-double' | 'jsx-single' | 'avoid-escape')[];
 	/**
 	 * Enforces the radix parameter of parseInt
 	 */
-	'radix'?: boolean;
+	radix?: boolean;
 	/**
 	 * When adding two variables, operands must both be of type number or of type string
 	 */
@@ -610,7 +689,7 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces semicolons at the end of every statement
 	 */
-	'semicolon'?: (true | false | 'always' | 'never' | 'ignore-bound-class-methods' | 'ignore-interfaces')[];
+	semicolon?: (true | false | 'always' | 'never' | 'ignore-bound-class-methods' | 'ignore-interfaces')[];
 	/**
 	 * Enforces a default case in switch statements
 	 */
@@ -634,19 +713,28 @@ export interface Jsruledefinitions {
 	/**
 	 * Enforces spacing whitespace
 	 */
-	'whitespace'?: (true | false | 'check-branch' | 'check-decl' | 'check-operator' | 'check-module' | 'check-separator' | 'check-type' | 'check-typecast')[];
+	whitespace?: (
+		| true
+		| false
+		| 'check-branch'
+		| 'check-decl'
+		| 'check-operator'
+		| 'check-module'
+		| 'check-separator'
+		| 'check-type'
+		| 'check-typecast')[];
 	[k: string]: any;
 }
 export interface JsonSchemaForTheTsLintConfigurationFiles {
 	/**
 	 * The directory where the codelytics rules live
 	 */
-	'rulesDirectory'?: string[];
-	'rules'?: Ruledefinitions;
-	'jsRules'?: Jsruledefinitions;
+	rulesDirectory?: string[];
+	rules?: Ruledefinitions;
+	jsRules?: Jsruledefinitions;
 	/**
 	 * Extend another configuration (built in config OR a node resolvable .json file)
 	 */
-	'extends'?: any[] | string;
+	extends?: any[] | string;
 	[k: string]: any;
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -4,7 +4,7 @@ export let verboseFlag = false;
  * Log a message to the console
  * @param text The message to be logged
  */
-export function log(... text: any[]) {
+export function log(...text: any[]) {
 	console.log(text.join(''));
 }
 
@@ -12,11 +12,11 @@ export function log(... text: any[]) {
  * Log a message to the console if verbose messages are desired
  * @param text The message to be logged
  */
-export function verbose(... text: any[]) {
+export function verbose(...text: any[]) {
 	if (!verboseFlag) {
 		return;
 	}
-	log(... text);
+	log(...text);
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,15 +11,14 @@ export interface ExportArgs {
 	verbose: boolean;
 }
 
-function buildNpmDependencies(): { [ pkg: string ]: string } {
+function buildNpmDependencies(): { [pkg: string]: string } {
 	try {
 		const packagePath = pkgDir.sync(__dirname);
 		const packageJsonFilePath = join(packagePath, 'package.json');
-		const packageJson = <any> require(packageJsonFilePath);
+		const packageJson = <any>require(packageJsonFilePath);
 
 		return packageJson.dependencies;
-	}
-	catch (e) {
+	} catch (e) {
 		throw new Error('Failed reading dependencies from "package.json" - ' + e.message);
 	}
 }
@@ -30,14 +29,16 @@ const command: Command<ExportArgs> = {
 	register(options: OptionsHelper) {
 		options('c', {
 			alias: 'content',
-			describe: 'A comma separated list of extensions of files to include in the project files.  Defaults to ' +
+			describe:
+				'A comma separated list of extensions of files to include in the project files.  Defaults to ' +
 				'"ts,html,css,json,xml,md".',
 			type: 'string'
 		});
 
 		options('i', {
 			alias: 'index',
-			describe: 'A file path to the main HTML document to load when running the project.  Defaults to ' +
+			describe:
+				'A file path to the main HTML document to load when running the project.  Defaults to ' +
 				'"./src/index.html".'
 		});
 

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -27,15 +27,14 @@ export default class MockModule {
 			let dependency;
 			try {
 				dependency = require(resolvePath(this.basePath, dependencyName));
-			}
-			catch (e) {
+			} catch (e) {
 				dependency = {};
 			}
 			const mock: any = {};
 
 			for (let prop in dependency) {
 				if (typeof dependency[prop] === 'function') {
-					mock[prop] = function () {};
+					mock[prop] = function() {};
 					this.sandbox.stub(mock, prop);
 				} else {
 					mock[prop] = dependency[prop];
@@ -46,8 +45,7 @@ export default class MockModule {
 				const ctor = this.sandbox.stub().returns(mock);
 				mockery.registerMock(dependencyName, ctor);
 				mock.ctor = ctor;
-			}
-			else {
+			} else {
 				mockery.registerMock(dependencyName, mock);
 			}
 			this.mocks[dependencyName] = mock;

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -8,7 +8,6 @@ import * as fs from 'fs';
 import MockModule from '../support/MockModule';
 
 describe('main', () => {
-
 	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let mockGenerateProjectJson: any;
@@ -36,20 +35,20 @@ describe('main', () => {
 		moduleUnderTest.register(options);
 
 		let untestedArguments: { [key: string]: string } = {
-			'c': 'content',
-			'i': 'index',
-			'o': 'out',
-			'p': 'project',
-			'v': 'verbose'
+			c: 'content',
+			i: 'index',
+			o: 'out',
+			p: 'project',
+			v: 'verbose'
 		};
 
 		for (let i = 0; i < options.callCount; i++) {
 			const call = options.getCall(i);
 
-			assert.isTrue(call.args[ 0 ] in untestedArguments);
-			assert.strictEqual(call.args[ 1 ].alias, untestedArguments[ call.args[ 0 ] ]);
+			assert.isTrue(call.args[0] in untestedArguments);
+			assert.strictEqual(call.args[1].alias, untestedArguments[call.args[0]]);
 
-			delete untestedArguments[ call.args[ 0 ] ];
+			delete untestedArguments[call.args[0]];
 		}
 
 		assert.isTrue(Object.keys(untestedArguments).length === 0, 'Not all commands are tested');
@@ -64,10 +63,17 @@ describe('main', () => {
 		};
 
 		const runTestArgs = { testArg: 'value' };
-		return moduleUnderTest.run(<any> helper, <any> runTestArgs).then(() => {
+		return moduleUnderTest.run(<any>helper, <any>runTestArgs).then(() => {
 			assert.isFalse(helper.command.run.calledOnce, 'Should not have called the command helper');
-			assert.isTrue(mockGenerateProjectJson.default.calledOnce, 'Should have called the GenerateProjectJson module');
-			assert.deepEqual(mockGenerateProjectJson.default.firstCall.args, [ runTestArgs ], 'Didn\'t run tests with provided arguments');
+			assert.isTrue(
+				mockGenerateProjectJson.default.calledOnce,
+				'Should have called the GenerateProjectJson module'
+			);
+			assert.deepEqual(
+				mockGenerateProjectJson.default.firstCall.args,
+				[runTestArgs],
+				"Didn't run tests with provided arguments"
+			);
 		});
 	});
 
@@ -86,8 +92,8 @@ describe('main', () => {
 		assert.isTrue('npm' in result, 'expecting npm property');
 		assert.isTrue('devDependencies' in result.npm, 'expecting a devDependencies property');
 		assert.deepEqual(result.npm.devDependencies, {
-			'dep1': 'dep1v',
-			'dep2': 'dep2v'
+			dep1: 'dep1v',
+			dep2: 'dep2v'
 		});
 	});
 
@@ -97,8 +103,7 @@ describe('main', () => {
 		try {
 			moduleUnderTest.eject({});
 			assert.fail('Should not have succeeded');
-		}
-		catch (e) {
+		} catch (e) {
 			assert.equal(e.message, 'Failed reading dependencies from "package.json" - test error');
 		}
 	});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"declaration": false,
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -30,15 +32,12 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,8 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-pascal-case", "allow-leading-underscore", "ban-keywords" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-pascal-case", "allow-leading-underscore", "ban-keywords" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206